### PR TITLE
Add text bubbling

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -18,13 +18,6 @@ if has("gui_macvim")
   map <D-/> <plug>NERDCommenterToggle<CR>
 endif
 
-" Bubble single lines
-nmap <C-Up> [e
-nmap <C-Down> ]e
-" Bubble multiple lines
-vmap <C-Up> [egv
-vmap <C-Down> ]egv
-
 " Start without the toolbar
 set guioptions-=T
 

--- a/vimrc
+++ b/vimrc
@@ -84,6 +84,13 @@ map <Leader>te :tabe <C-R>=expand("%:p:h") . "/" <CR>
 " Command mode: Ctrl+P
 cmap <C-P> <C-R>=expand("%:p:h") . "/" <CR>
 
+" Bubble single lines
+nmap <C-Up> [e
+nmap <C-Down> ]e
+" Bubble multiple lines
+vmap <C-Up> [egv
+vmap <C-Down> ]egv
+
 " Use modeline overrides
 set modeline
 set modelines=10


### PR DESCRIPTION
Textmate/eclipse style ability to move lines of text up or down for refactoring. Add's Tim Pope's unimpaired plugin and maps ctrl+up and ctrl+down over unimpaired's less-intuitive commands, just like the VimCasts example.  
