### PR TITLE
Fixing README for new Github URLs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ report an issue to the issue tracker.
 
 or
 
-  `curl http://github.com/carlhuda/janus/raw/master/bootstrap.sh -o - | sh`
+  `curl https://github.com/carlhuda/janus/raw/master/bootstrap.sh -o - | sh`
 
 ## Updating to the latest version
 


### PR DESCRIPTION
Github does a 301 on all http URLs now, breaking the bootstrap oneliner.
