### PR TITLE
Added softtabstop

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -8,6 +8,7 @@ syntax on
 set nowrap
 set tabstop=2
 set shiftwidth=2
+set softtabstop=2
 set expandtab
 set list listchars=tab:\ \ ,trail:·
 


### PR DESCRIPTION
The softtabstop setting was missing, therefore backspace only deleted one space of a soft indent.
