### PR TITLE
Readme links bootstrap.sh to invalid non-secure address

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ report an issue to the issue tracker.
 
 or
 
-  `curl http://github.com/carlhuda/janus/raw/master/bootstrap.sh -o - | sh`
+  `curl https://github.com/carlhuda/janus/raw/master/bootstrap.sh -o - | sh`
 
 ## Updating to the latest version
 


### PR DESCRIPTION
Fix readme's bootstrap.sh uri to point to the new SSL enabled address as
non-secure linking works no more (GitHub sidejack prevention)
