### PR TITLE
Changed curl installation url to https since github now redirects http to https and curl doesn't follow. 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ report an issue to the issue tracker.
 
 or
 
-  `curl http://github.com/carlhuda/janus/raw/master/bootstrap.sh -o - | sh`
+  `curl https://github.com/carlhuda/janus/raw/master/bootstrap.sh -o - | sh`
 
 ## Updating to the latest version
 


### PR DESCRIPTION
Changed curl installation url to https since github now redirects http to https and curl doesn't follow. 
