### PR TITLE
Use rvm ruby if rvm is detected

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -149,7 +149,7 @@ vim_plugin_task "command_t",        "git://github.com/wincent/Command-T.git" do
   sh "find ruby -name '.gitignore' | xargs rm"
   Dir.chdir "ruby/command-t" do
     if `rvm > /dev/null 2>&1` && $?.exitstatus == 0
-      sh "rvm system ruby extconf.rb"
+      sh "rvm ruby extconf.rb"
     else
       sh "/usr/bin/ruby extconf.rb" # assume /usr/bin/ruby is system ruby
     end


### PR DESCRIPTION
If you're using rvm, you probably want to use your currently selected rvm ruby.

If you're like me, you don't even have a system ruby installed on some machines.
