### PR TITLE
Spelled "mustasche" as "mustache" in Rakefile + Added endwise plugin

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,4 @@
 for i in ~/.vim ~/.vimrc ~/.gvimrc; do [ -e $i ] && mv $i $i.old; done
-#git clone git://github.com/carlhuda/janus.git ~/.vim
-git clone git://github.com/larssmit/janus.git ~/.vim
+git clone git://github.com/carlhuda/janus.git ~/.vim
 cd ~/.vim
 rake


### PR DESCRIPTION
Spelled "mustasche" as "mustache" in Rakefile. When you do a rake task, this mispelling could be annoying. 

Also added the endwise plugin that helps to end certain code structures automatically: http://www.vim.org/scripts/script.php?script_id=2386

Thanks for the good work on Janus!

Best regards,
Lars Smit
