### PR TITLE
Add bufexplorer plugin

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -154,6 +154,7 @@ vim_plugin_task "syntastic",        "git://github.com/scrooloose/syntastic.git"
 vim_plugin_task "puppet",           "git://github.com/ajf/puppet-vim.git"
 vim_plugin_task "scala",            "git://github.com/bdd/vim-scala.git"
 vim_plugin_task "gist-vim",         "git://github.com/mattn/gist-vim.git"
+vim_plugin_task "bufexplorer",      "git://github.com/vim-scripts/bufexplorer.zip.git"
 
 vim_plugin_task "command_t",        "git://github.com/wincent/Command-T.git" do
   sh "find ruby -name '.gitignore' | xargs rm"


### PR DESCRIPTION
With bufexplorer, you can quickly and easily switch between buffers by using the one of the default public interfaces: 
-   '\be' (normal open)  or 
-   '\bs' (force horizontal split open)  or 
-   '\bv' (force vertical split open) 

Once the bufexplorer window is open you can use the normal movement keys (hjkl) to move around and then use <Enter> or <Left-Mouse-Click> to select the buffer you would like to open. If you would like to have the selected buffer opened in a new tab, simply press either <Shift-Enter> or 't'. Please note that when opening a buffer in a tab, that if the buffer is already in another tab, bufexplorer can switch to that tab automatically for you if you would like. More about that in the supplied VIM help. 

Bufexplorer also offers various options including:
-   Display the list of buffers in various sort orders including: 
  -   Most Recently Used (MRU) which is the default 
  -   Buffer number 
  -   File name 
  -   File extension 
  -   Full file path name 
-   Delete buffer from list 
