### PR TITLE
Error with :Edit

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -188,7 +188,7 @@ ruby << RUBY
   home        = pwd == File.expand_path("~")
 
   if home || Regexp.new("^" + Regexp.escape(pwd)) !~ destination
-    VIM.command(%{call ChangeDirectory(system("dirname " . shellescape(a:file, 1)), 0)})
+    VIM.command(%{call ChangeDirectory(fnamemodify(a:file, ":h"), 0)})
   end
 RUBY
 endfunction


### PR DESCRIPTION
`dirname` adds a newline which causes `:Edit ~/.vimrc` to fail with:
    E344: Can't find directory "/Users/kassens^@" in cdpath
This bug is fixed for me in my `edit-path-bug` branch.
