### PR TITLE
Added a streamlined install path to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,13 @@ or
 
   `curl https://github.com/carlhuda/janus/raw/master/bootstrap.sh -o - | sh`
 
+or
+
+If you use [Babushka](http://babushka.me) you can using the following script to install Janus
+along with MacVim (will also setup mvim on your path)
+
+  `babushka joshholt:janus`
+
 ## Customization
 
 Create `~/.vimrc.local` and `~/.gvimrc.local` for any local


### PR DESCRIPTION
The streamlined install path that I have added to the README points the user to one of my Babushka scripts that will automatically install Janus + MacVim + the mvim command along with any dependencies needed.
