### PR TITLE
vim.org/scripts problems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -192,7 +192,7 @@ vim_plugin_task "janus_themes" do
 end
 
 vim_plugin_task "molokai" do
-  sh "curl http://www.vim.org/scripts/download_script.php?src_id=9750 > colors/molokai.vim"
+  sh "curl https://github.com/mrtazz/molokai.vim/blob/master/colors/molokai.vim > colors/molokai.vim"
 end
 vim_plugin_task "mustache" do
   sh "curl https://github.com/defunkt/mustache/raw/master/contrib/mustache.vim > syntax/mustache.vim"


### PR DESCRIPTION
Hi,

vim.org/scripts has connection problems recently and as a result the Janus install fails.
Fortunately there is a mirror of vim.org/scripts on github so i replaced the urls in the Janus Rakefile to make the install work.

best,
Viktor
