### PR TITLE
Ubuntu package depencies

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,9 +28,10 @@ OSX (via Terminal), or with any other `vim` or `gvim` installation.
 
 Linux users can install `gvim` for an experience identical to MacVim.
 On Debian/Ubuntu, simply `apt-get install vim-gnome`. For remote
-servers, install console vim with `apt-get install vim-nox`. If you are
-not yet a ruby developer, you will propably also need to install `rake` and
-`ruby-dev` before installing the janus distribution.
+servers, install console vim with `apt-get install vim-nox`. On a fresh
+Ubuntu install you also have to install the packages `rake` and `ruby-dev`
+before running the install script and `exuberant-ctags` for ctags
+support.
 
 ## Installation
 


### PR DESCRIPTION
On a vanilla Ubuntu, the install script will not work because of the missing rake and ruby-dev packages. I extended the README with that information.

Thank you for the plugin compilation!

Regards
