### PR TITLE
Reading from STDIN

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -85,7 +85,7 @@ function s:CdIfDirectory(directory)
     exe "cd " . fnameescape(a:directory)
   endif
 
-  " Allows read from stdin without displaying an error
+  " Allows reading from stdin
   " ex: git diff | mvim -R -
   if strlen(a:directory) == 0 
     return


### PR DESCRIPTION
Allows reading from STDIN without displaying an error (or not working at all and just opening the current directory in NERDTree). The problem was in the CdIfDirectory method in gvimrc. 

ex: git diff | mvim -R -
