### PR TITLE
Fix cmd t help

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,7 @@ def vim_plugin_task(name, repo=nil)
           else
             subdirs.each do |subdir|
               if File.exists?(subdir)
-                sh "cp -rf #{subdir}/* #{cwd}/#{subdir}/"
+                sh "cp -RfL #{subdir}/* #{cwd}/#{subdir}/"
               end
             end
           end


### PR DESCRIPTION
:help command-t doesn't work, and if you look at ~/.vim/doc/command-t.txt, you'll see why.  On general principle, when building a file structure the way this Rakefile does, we really ought to be dereferencing symlinks anyway.
