### PR TITLE
Remove test/fixtures/* from the ignore list

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -23,7 +23,7 @@ set smartcase
 
 " Tab completion
 set wildmode=list:longest,list:full
-set wildignore+=*.o,*.obj,.git,*.rbc,*.class,.svn,test/fixtures/*,vendor/gems/*
+set wildignore+=*.o,*.obj,.git,*.rbc,*.class,.svn,vendor/gems/*
 
 " Status bar
 set laststatus=2


### PR DESCRIPTION
Took me a while to track this down, but without this change it's pretty well impossible to open the fixture files to edit.  Both cmd-t and :Edit won't let you navigate there.
