### PR TITLE
Any reason not to use https?

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -198,10 +198,10 @@ vim_plugin_task "janus_themes" do
 end
 
 vim_plugin_task "molokai" do
-  sh "curl https://github.com/mrtazz/molokai.vim/raw/master/colors/molokai.vim > colors/molokai.vim"
+  sh "curl --insecure https://github.com/mrtazz/molokai.vim/raw/master/colors/molokai.vim > colors/molokai.vim"
 end
 vim_plugin_task "mustache" do
-  sh "curl https://github.com/defunkt/mustache/raw/master/contrib/mustache.vim > syntax/mustache.vim"
+  sh "curl --insecure https://github.com/defunkt/mustache/raw/master/contrib/mustache.vim > syntax/mustache.vim"
   File.open(File.expand_path('../ftdetect/mustache.vim', __FILE__), 'w') do |file|
     file << "au BufNewFile,BufRead *.mustache        setf mustache"
   end
@@ -212,7 +212,7 @@ vim_plugin_task "arduino","https://github.com/vim-scripts/Arduino-syntax-file.gi
   end
 end
 vim_plugin_task "vwilight" do
-  sh "curl https://gist.github.com/raw/796172/724c7ca237a7f6b8d857c4ac2991cfe5ffb18087/vwilight.vim > colors/vwilight.vim"
+  sh "curl --insecure https://gist.github.com/raw/796172/724c7ca237a7f6b8d857c4ac2991cfe5ffb18087/vwilight.vim > colors/vwilight.vim"
 end
 
 if File.exists?(janus = File.expand_path("~/.janus.rake"))


### PR DESCRIPTION
I tried to set up Janus at work today and found that the links to the repos for the extensions, etc, use the git protocol and not https. Our firewall blocks the git port, so I've switched to https for github repos. Do you think anyone else would find this useful? Any reason not to use https? Thanks.
