### PR TITLE
Getting Janus to work in Cygwin

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -231,7 +231,7 @@ task :link_vimrc do
   %w[ vimrc gvimrc ].each do |file|
     dest = File.expand_path("~/.#{file}")
     unless File.exist?(dest)
-      ln_s(File.expand_path("../#{file}", __FILE__), dest)
+      sh "ln -s " + File.expand_path("../#{file}", __FILE__) + " " + dest
     end
   end
 end


### PR DESCRIPTION
I spent some time today trying to get Janus to install in Cygwin and ran into a few issues.

Cygwin's curl doesn't support curling of an https address because, as far as I can understand, it isn't able to check the cert. It fails hard and requires the --insecure to work.

Another issue I've run into is the ln_s call right at the end of the installation. Since sh is used elsewhere, why not just use it for the soft linking?

I know this is kind of obtuse and Windows isn't the target environment (trust me, I wish I didn't have to use it either, Mac at home), but I thought this might be useful for others. Let me know. Thanks.
