### PR TITLE
Show partial command in the status line.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -137,6 +137,9 @@ let macvim_hig_shift_movement = 1
 " % to bounce from do to end etc.
 runtime! macros/matchit.vim
 
+" Show (partial) command in the status line
+set showcmd
+
 " Include user's local vim config
 if filereadable(expand("~/.vimrc.local"))
   source ~/.vimrc.local


### PR DESCRIPTION
This change adds 'set showcmd' so that as you are typing the prefix to a multi-character command, you can see what you're typing on the status line.
