### PR TITLE
Mercurial repo to rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,9 @@ def vim_plugin_task(name, repo=nil)
         if repo =~ /git$/
           sh "git clone #{repo} #{dir}"
 
+        elsif repo =~ %r{(^hg://)(.+)}
+          sh "hg clone https://#{$2} #{dir}"
+
         elsif repo =~ /download_script/
           if filename = `curl --silent --head #{repo} | grep attachment`[/filename=(.+)/,1]
             filename.strip!


### PR DESCRIPTION
I wanted to add a vim plugin that had it's source on bitbucket ~.~ so I added a hg type repo to the Rakefile.

I'm not sure of a reliable way to detect Mercurial so I cheat and swap https:// to hg:// in the ~/.janus.rake and then switch back when doing the actual cloning. I'm not familiar with hg so if anyone knows a better way let me know. I thought about a regexp for bitbucket urls but felt that might be too specific. 

Ex.
// original_url => hg clone https://bitbucket.org/sjl/gundo.vim

// ./janus.rake 

vim_plugin_task "gundo-vim",        "hg://bitbucket.org/sjl/gundo.vim"
