### PR TITLE
insert mode command i (comment support)

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -1,4 +1,3 @@
-
 if has("gui_macvim")
   " Fullscreen takes up entire screen
   set fuoptions=maxhorz,maxvert
@@ -19,6 +18,8 @@ if has("gui_macvim")
 
   " Command-/ to toggle comments
   map <D-/> <plug>NERDCommenterToggle<CR>
+  imap <D-/> <Esc><plug>NERDCommenterToggle<CR>i
+
 
   " Command-][ to increase/decrease indentation
   vmap <D-]> >gv


### PR DESCRIPTION
hi i've added an _insert_ mode (not as stated in commit) support for comments. i'm not sure why it is not mapped by default.
thanks
d. 
