### PR TITLE
vim_plugin_task block should be within chdir when running yield.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,9 +97,8 @@ def vim_plugin_task(name, repo=nil)
               end
             end
           end
+          yield if block_given?
         end
-
-        yield if block_given?
       end
     else
       task :install => subdirs do


### PR DESCRIPTION
The assumption inside vim_plugin_task block (command_t for eg) is to be within the plugin folder, and not .vim folder
