### PR TITLE
Closes #171 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'rubygems'
+
 module VIM
   Dirs = %w[ after autoload doc plugin ruby snippets syntax ftdetect ftplugin colors indent ]
 end
@@ -155,7 +157,12 @@ vim_plugin_task "scala",            "git://github.com/bdd/vim-scala.git"
 vim_plugin_task "gist-vim",         "git://github.com/mattn/gist-vim.git"
 
 vim_plugin_task "hammer",           "git://github.com/robgleeson/hammer.vim.git" do
-  sh "gem install github-markup redcarpet"
+  if Gem.cache.find_name('github-markup').length == 0:
+    sh "gem install github-markup"
+  end
+  if Gem.cache.find_name('redcarpet').length == 0:
+    sh "gem install redcarpet"
+  end
 end
 
 vim_plugin_task "command_t",        "http://s3.wincent.com/command-t/releases/command-t-1.2.1.vba" do


### PR DESCRIPTION
Check for gem's existence before trying to install them. That way, on systems where the GEM_HOME is not user-writeable, it's still possible to install Janus by first manually installing those gems and then calling rake.
