### PR TITLE
Skip installation of plugins that you don't want

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,15 @@ If you want to add additional Vim plugins you can do so by adding a
     vim_plugin_task "zencoding", "git://github.com/mattn/zencoding-vim.git"
     vim_plugin_task "minibufexpl", "git://github.com/fholgado/minibufexpl.vim.git"
 
+If you do not wish to use one of the plugins Janus provides out of the
+box you can have it skipped using the `skip_plugin_task` method in
+`~/.janus.rake`:
+
+    skip_plugin_task "color-sampler"
+
+**Note**: Skipping the plugin will only apply to installation. It won't
+remove configurations or mappings Janus might have added for it.
+
 ## Updating to the latest version
 
 To update to the latest version of the distribution, just run `rake`

--- a/Rakefile
+++ b/Rakefile
@@ -120,6 +120,10 @@ def vim_plugin_task(name, repo=nil)
   task :default => name
 end
 
+def skip_vim_plugin(name)
+  Rake::Task[:default].prerequisites.delete(name)
+end
+
 vim_plugin_task "ack.vim",          "git://github.com/mileszs/ack.vim.git"
 vim_plugin_task "color-sampler",    "git://github.com/vim-scripts/Color-Sampler-Pack.git"
 vim_plugin_task "conque",           "http://conque.googlecode.com/files/conque_1.1.tar.gz"


### PR DESCRIPTION
I added support for flagging plugins to be skipped in your `~/.janus.rake`. Rake tasks for the skipped plugins remain in place, they're just not run by default.
