### PR TITLE
Fixed readme for `skip_vim_plugin` method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,10 +63,10 @@ If you want to add additional Vim plugins you can do so by adding a
     vim_plugin_task "minibufexpl", "git://github.com/fholgado/minibufexpl.vim.git"
 
 If you do not wish to use one of the plugins Janus provides out of the
-box you can have it skipped using the `skip_plugin_task` method in
+box you can have it skipped using the `skip_vim_plugin` method in
 `~/.janus.rake`:
 
-    skip_plugin_task "color-sampler"
+    skip_vim_plugin "color-sampler"
 
 **Note**: Skipping the plugin will only apply to installation. It won't
 remove configurations or mappings Janus might have added for it.


### PR DESCRIPTION
sorry for the mistake, and thank @vguerci for pointing out
