### PR TITLE
Fixing a typo in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -211,7 +211,7 @@ There's a lot more; check it out at `:help surround`
 ## NERDCommenter
 
 NERDCommenter allows you to wrangle your code comments, regardless of
-filetype. View `help :NERDCommenter` for all the details.
+filetype. View `:help NERDCommenter` for all the details.
 
 **Customizations**: Janus binds command-/ (`<D-/>`) to toggle comments.
 


### PR DESCRIPTION
Fixing a typo in the README: it’s `:help NERDCommenter` not `help :NERDCommenter`.
