### PR TITLE
switch to git mirror of conque

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,7 +126,7 @@ end
 
 vim_plugin_task "ack.vim",          "git://github.com/mileszs/ack.vim.git"
 vim_plugin_task "color-sampler",    "git://github.com/vim-scripts/Color-Sampler-Pack.git"
-vim_plugin_task "conque",           "http://conque.googlecode.com/files/conque_1.1.tar.gz"
+vim_plugin_task "conque",           "git://github.com/rson/vim-conque.git"
 vim_plugin_task "fugitive",         "git://github.com/tpope/vim-fugitive.git"
 vim_plugin_task "git",              "git://github.com/tpope/vim-git.git"
 vim_plugin_task "haml",             "git://github.com/tpope/vim-haml.git"
@@ -258,4 +258,3 @@ task :default => [
 
 desc "Clear out all build artifacts and rebuild the latest Janus"
 task :upgrade => [:clean, :pull, :default]
-


### PR DESCRIPTION
Alternatively, the tarball could be upgraded from 1.1 to 2.1, however this github mirror of the SVN repository is up to date, so I suggest we just use that.
