### PR TITLE
command-t vs. windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -170,8 +170,10 @@ vim_plugin_task "command_t",        "http://s3.wincent.com/command-t/releases/co
       sh "/usr/bin/ruby extconf.rb"
     elsif `rvm > /dev/null 2>&1` && $?.exitstatus == 0
       sh "rvm system ruby extconf.rb"
+    else
+      sh "ruby extconf.rb"
     end
-    sh "make clean && make"
+    sh "make clean all"
   end
 end
 


### PR DESCRIPTION
Janus rakefile contains some code which assumes it's in a rather standard unix-y environment. I tried to set up janus with mysysgit, and it worked more or less, except CommandT. As it turned out, it's very easy to fix, which should still work in current environments. This patch alone won't make Janus ultimately compatible with Windows (see :link_vimrc task), but now it does most of the job.

Besides, in windows, building CommandT requires Devkit shell with git executable in %PATH%, and running it requires [Wu Yongwei's gvim build](http://wyw.dcweb.cn/#download). The latter is required because www.vim.org's version is rather old, and it still doesn't contain patch 88, which [solves the problem](https://wincent.com/issues/1647#comment_6543).
