### PR TITLE
macvim external commands hangs when using zsh

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,5 +1,8 @@
 set nocompatible
 
+"use bash for external commands
+set shell=bash
+
 set number
 set ruler
 syntax on


### PR DESCRIPTION
Hi, your code is awesome, works great, but only on bash, when switched to zsh (oh-my-zsh), then the external commands like TlistToggle, Gdiff and so one, stopped from working. In the process manager, I figured out, the wrong shell is called (not the bash shell). After some searching found stuff like this:

https://github.com/tpope/vim-fugitive/issues/58
http://code.google.com/p/macvim/issues/detail?id=346

so my solution is to put:

set shell=bash in the vimrc

Regards,
Wojciech

P.S Keep up the good job
