### PR TITLE
Cannot remap Leader from vimrc.local or gvimrc.local

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,3 +1,7 @@
+if filereadable(expand("~/.vimrc.before"))
+   source ~/.vimrc.before
+ endif
+
 set nocompatible
 
 set number


### PR DESCRIPTION
The Leader character must be defined before using Leader in any mappings. This means that setting Leader to be a different character must happen before `.vimrc` is loaded. I've set `.vimrc` to load a `~/.vimrc.before` at the top, so that Leader can be defined before it's used for any mappings.

I imagine there are other reasons a before hook could be useful. In my case, my `~/.vimrc.before` contains

```
let mapleader = ","
```
