### PR TITLE
Fix the Rakefile to work for directories with spaces in them.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ def vim_plugin_task(name, repo=nil)
     if repo
       file dir => "tmp" do
         if repo =~ /git$/
-          sh "git clone #{repo} #{dir}"
+          sh "git clone #{repo} #{dir.sub(/ /, '\ ')}"
 
         elsif repo =~ /download_script/
           if filename = `curl --silent --head #{repo} | grep attachment`[/filename=(.+)/,1]
@@ -36,13 +36,13 @@ def vim_plugin_task(name, repo=nil)
 
         case filename
         when /zip$/
-          sh "unzip -o tmp/#{filename} -d #{dir}"
+          sh "unzip -o tmp/#{filename} -d #{dir.sub(/ /, '\ ')}"
 
         when /tar\.gz$/
           dirname  = File.basename(filename, '.tar.gz')
 
           sh "tar zxvf tmp/#{filename}"
-          sh "mv #{dirname} #{dir}"
+          sh "mv #{dirname} #{dir.sub(/ /, '\ ')}"
 
         when /vba(\.gz)?$/
           if filename =~ /gz$/
@@ -93,7 +93,7 @@ def vim_plugin_task(name, repo=nil)
           else
             subdirs.each do |subdir|
               if File.exists?(subdir)
-                sh "cp -RfL #{subdir}/* #{cwd}/#{subdir}/"
+                sh "cp -RfL #{subdir}/* #{cwd.sub(/ /, '\ ')}/#{subdir}/"
               end
             end
           end


### PR DESCRIPTION
When passing in the dirname, you weren't handling the case where the dirname contained spaces, so things like:

/Volumes/Macintosh HD/Users/ctide/

would cause a bunch of failures, like:

rake aborted!
Command failed with status (64): [cp -RfL plugin/\* /Volumes/Macintosh HD/Use...]

Command failed with status (64): [mv conque_1.1 /Volumes/Macintosh HD/Users/...]
/Volumes/Macintosh HD/Users/ctide/.vim/Rakefile:45:in `vim_plugin_task'

etc.  This fixes that.
