### PR TITLE
Add ClosePairs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -156,6 +156,7 @@ vim_plugin_task "syntastic",        "git://github.com/scrooloose/syntastic.git"
 vim_plugin_task "puppet",           "git://github.com/ajf/puppet-vim.git"
 vim_plugin_task "scala",            "git://github.com/bdd/vim-scala.git"
 vim_plugin_task "gist-vim",         "git://github.com/mattn/gist-vim.git"
+vim_plugin_task "ClosePairs",      "git://github.com/danpal/ClosePairs.git"
 
 #vim_plugin_task "hammer",           "git://github.com/robgleeson/hammer.vim.git" do
 #  sh "gem install github-markup redcarpet"


### PR DESCRIPTION
ClosePairs (http://www.vim.org/scripts/script.php?script_id=2373) is an autoclose plugin. Autoclose plugins were removed see https://github.com/carlhuda/janus/commit/3a071dcf38540e9b94db8a246bd3b8c1ca8cbbf3
this is the only one that was not tried.
