### PR TITLE
Update README to help RVM users install Janus.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,6 +46,16 @@ or
 
   `curl https://raw.github.com/carlhuda/janus/master/bootstrap.sh -o - | sh`
 
+Note that MacVim and Janus must be compiled using the same version of
+Ruby.  This may cause problems for users of RVM or rbenv.  To solve,
+execute:
+
+    rvm system
+    brew uninstall macvim
+    brew install macvim
+    curl https://raw.github.com/carlhuda/janus/master/bootstrap.sh -o - | sh
+    rvm default
+
 ## Customization
 
 Create `~/.vimrc.local` and `~/.gvimrc.local` for any local


### PR DESCRIPTION
RVM users will hit a segfault on startup if MacVim was compiled with a different version of Ruby.  This commit mentions this issue in the README and gives instructions on how to avoid it.

This pull request would solve https://github.com/carlhuda/janus/issues/244.
