### PR TITLE
Add compiler directory for vim-coffee-script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ colors
 indent
 .VimballRecord
 backup
+compiler

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 module VIM
-  Dirs = %w[ after autoload doc plugin ruby snippets syntax ftdetect ftplugin colors indent backup ]
+  Dirs = %w[ after autoload compiler doc plugin ruby snippets syntax ftdetect ftplugin colors indent backup ]
 end
 
 directory "tmp"


### PR DESCRIPTION
This fixes compatibility with vim-coffee-script which has recently
(kchmck/vim-coffee-script@4a1076388849adf3cb1669d4ac7ffd6ee7637844) added a compiler script.
