### PR TITLE
Added compiler to VIM::Dirs to enable compilers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 module VIM
-  Dirs = %w[ after autoload doc plugin ruby snippets syntax ftdetect ftplugin colors indent backup ]
+  Dirs = %w[ after autoload doc plugin ruby snippets syntax ftdetect ftplugin colors indent backup compiler ]
 end
 
 directory "tmp"


### PR DESCRIPTION
This enables plugins with compilers to work, such as vim-coffescript.
