### PR TITLE
[Experimental] Rakefile: Add support for plugin installation.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,9 @@
+module Janus
+  # Errors
+  JanusError = Class.new Exception
+  BlockNotGivenError = Class.new JanusError
+end
+
 # Return the root path
 #
 # @return [String] The absolute path to Janus repository
@@ -9,8 +15,41 @@ def expand(file)
   File.expand_path(file)
 end
 
+# Install a plugin
+#
+# @param [String] The group the plugin belongs to
+# @param [String] The plugin name
+# @param [&block] The installation block
+def install_vim_plugin(group, name, &block)
+  raise Janus::BlockNotGivenError unless block_given?
+
+  # Create a namespace for the plugin
+  namespace(name) do
+    task :verify_plugin do
+      unless Dir["#{root_path}/#{group}/#{name}/**"].any?
+        abort "The submodule #{group}/#{name} is not ready, please run 'git submodule update --init'"
+      end
+    end
+
+    # Define the plugin installation task
+    desc "Install #{name} plugin."
+    task :install do
+      puts
+      puts "*" * 40
+      puts "*#{"Installing #{name}".center(38)}*"
+      puts "*" * 40
+      puts
+      yield
+    end
+    task :install => :verify_plugin
+  end
+
+  # Hook the plugin's install task to the global install task
+  task :install => "#{name}:install"
+end
+
 # Load all plugin installation tasks
-Dir["#{root_path}/janus-*/tasks/**.rake"].each { |f| load f }
+Dir["#{root_path}/janus-*/tasks/**.rake"].each { |f| import f }
 
 task expand("~/.vimrc") => "vimrc" do
   sh "ln -s ~/.vim/vimrc ~/.vimrc"


### PR DESCRIPTION
This commit adds support for plugins that needs special installations for example, command-t needs to be compiled.

See [command-t.rake](https://github.com/TechnoGate/janus/blob/experimental/janus-tools/tasks/command-t.rake) for an example.
