### PR TITLE
[Experimental] Vimrc: Enable vimrc customisations.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -156,14 +156,6 @@ cmap <C-P> <C-R>=expand("%:p:h") . "/"
 
 
 ""
-"" Customizations
-""
-
-if filereadable(expand("~/.vimrc.after"))
-  source ~/.vimrc.after
-endif
-
-""
 "" Disable swap files
 ""
 


### PR DESCRIPTION
Adds support for **~/.vimrc.before** and **~/.vimrc.after** files
