### PR TITLE
[Experimental] Vimrc: Invoke pathogen helptags.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -39,6 +39,7 @@ call s:add_group("janus-colors")
 call s:add_group("janus-command-t")
 
 call pathogen#runtime_append_all_bundles()
+call pathogen#helptags()
 
 ""
 "" Basic Setup


### PR DESCRIPTION
Load the helptags of all installed plugins.
