### PR TITLE
Add support for rbenv to command_t install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -170,6 +170,8 @@ vim_plugin_task "command_t",        "http://s3.wincent.com/command-t/releases/co
       sh "/usr/bin/ruby extconf.rb"
     elsif `rvm > /dev/null 2>&1` && $?.exitstatus == 0
       sh "rvm system ruby extconf.rb"
+    elsif `rbenv > /dev/null 2>&1` && $?.exitstatus == 0
+      sh "RBENV_VERSION=system ruby extconf.rb"
     end
     sh "make clean && make"
   end


### PR DESCRIPTION
I use rbenv rather than rvm, and the command_t installer was failing because none of the existing codepaths was sufficient to find rbenv. This patch adds explicit rbenv support and will properly call the system ruby to run extconf.rb.
