### PR TITLE
Group NERDTree-related autocommands within an :augroup

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -84,9 +84,10 @@ endfunction
 
 " Project Tree
 if exists("loaded_nerd_tree")
-  autocmd VimEnter * call s:CdIfDirectory(expand("<amatch>"))
-  autocmd FocusGained * call s:UpdateNERDTree()
-  autocmd WinEnter * call s:CloseIfOnlyNerdTreeLeft()
+  augroup AuNERDTreeCmd
+  autocmd AuNERDTreeCmd VimEnter * call s:CdIfDirectory(expand("<amatch>"))
+  autocmd AuNERDTreeCmd FocusGained * call s:UpdateNERDTree()
+  autocmd AuNERDTreeCmd WinEnter * call s:CloseIfOnlyNerdTreeLeft()
 endif
 
 " Close all open buffers on entering a window if the only


### PR DESCRIPTION
### Problem

I'm working with a pretty big project, and I don't want NERDTree to refresh on every `FocusGained` event. It just takes way too long on my system.

I could use the following command:

```
:autocmd! FocusGained
```

but this would remove **all** autocommands for this event.
### Solution

I propose an `:augroup` for the three `:autocmd`s related to NERDTRee. This way I can clearly target the specific autocommand in the current session or in `.gvimrc.local`:

```
:autocmd! AuNERDTreeCmd FocusGained
```
### Notes
- See attached code for the solution
- `AuNERDTreeCmd` name is inspired by another group name I found in my config: `AuNetrwShellCmd`. I believe this follows the convention.
