### PR TITLE
Use <C-k> and <C-j> to "bubble" (multiple) lines

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -106,9 +106,13 @@ cmap <C-P> <C-R>=expand("%:p:h") . "/" <CR>
 " Bubble single lines
 nmap <C-Up> [e
 nmap <C-Down> ]e
+nmap <C-k> [e
+nmap <C-j> ]e
 " Bubble multiple lines
 vmap <C-Up> [egv
 vmap <C-Down> ]egv
+vmap <C-k> [egv
+vmap <C-j> ]egv
 
 " Enable syntastic syntax checking
 let g:syntastic_enable_signs=1


### PR DESCRIPTION
In addition to using using <C-Up> and <C-Down> this allows "bubbling" lines
with  <C-k> and <C-j>, for users that prefer to use hjkl over the arrow
keys.
