### PR TITLE
Load .vimrc.after after the janus core plugins

### DIFF
--- a/janus/vim/core/after/plugin/vimrc_after.vim
+++ b/janus/vim/core/after/plugin/vimrc_after.vim
@@ -1,0 +1,8 @@
+" Customization
+"
+" This loads after the janus plugins so that janus-specific plugin mappings can
+" be overwritten.
+
+if filereadable(expand("~/.vimrc.after"))
+  source ~/.vimrc.after
+endif

--- a/janus/vim/vimrc
+++ b/janus/vim/vimrc
@@ -2,7 +2,7 @@
 "" Janus setup
 ""
 
-" Define pathes
+" Define paths
 let g:janus_path = fnamemodify(resolve(expand("<sfile>:p")), ":h")
 let g:janus_vim_path = fnamemodify(resolve(expand("<sfile>:p" . "vim")), ":h")
 
@@ -32,10 +32,4 @@ endif
 " Load all groups
 call janus#load_pathogen()
 
-""
-"" Customizations
-""
-
-if filereadable(expand("~/.vimrc.after"))
-  source ~/.vimrc.after
-endif
+" .vimrc.after is loaded after the plugins have loaded


### PR DESCRIPTION
As referenced in #308, as a separate pull request. Load the `.vimrc.after` after the janus core plugins have initialized.
