### PR TITLE
Add ~/.janus directory to pathogen if it exists

### DIFF
--- a/janus/vim/core/before/plugin/janus.vim
+++ b/janus/vim/core/before/plugin/janus.vim
@@ -32,15 +32,17 @@ endfunction
 " Add a group of plug-ins to Pathogen
 "
 " @param [String] The plugin name
-function! janus#add_group(name)
+" @param [String] (Optional) the base path of the group
+function! janus#add_group(name, ...)
   if !exists("g:janus_loaded_groups")
     let g:janus_loaded_groups = []
   endif
 
-  call add(g:janus_loaded_groups, a:name)
+  let base_path = exists("a:1") ? a:1 : g:janus_vim_path
+  call add(g:janus_loaded_groups, base_path . janus#separator() . a:name)
 endfunction
 
-" Load pathgoen groups
+" Load pathogen groups
 function! janus#load_pathogen()
   if !exists("g:loaded_pathogen")
     " Source Pathogen
@@ -48,7 +50,7 @@ function! janus#load_pathogen()
   endif
 
   for group in g:janus_loaded_groups
-    call pathogen#runtime_prepend_subdirectories(g:janus_vim_path. janus#separator() . group)
+    call pathogen#runtime_prepend_subdirectories(group)
   endfor
 
   call pathogen#runtime_append_all_bundles()

--- a/janus/vim/vimrc
+++ b/janus/vim/vimrc
@@ -14,6 +14,12 @@ exe 'source ' . g:janus_vim_path . '/core/before/plugin/janus.vim'
 call janus#add_group("tools")
 call janus#add_group("langs")
 call janus#add_group("colors")
+
+" add custom ~/.janus directory to pathogen if it exists
+if isdirectory(expand("~/.janus"))
+  call janus#add_group(".janus", expand("~"))
+endif
+
 call janus#add_group("custom")
 call janus#add_group("core")
 


### PR DESCRIPTION
For easy customization in a separately-managed directory.

Based on your (@eMxyzptlk) comment on #308, it sounds like this is the best solution for a fully-customizable janus configuration without having to touch the janus repo itself. You said:

> - custom folder still uses pathogen
> - custom folder is loaded before other groups but after the core (obviously)
> - users can use different plugins version and since every plugin prevent vim from re-loading itself, anyone can overload a janus plugin
> - _most most important_ It can be a separate git repository and users wouldn't be obliged to maintain a fork just to keep track of their custom things.

And this meets those requirements.

If you decide to go with this pattern, we could drop the `janus/vim/custom` directory altogether since this gives the same customizability and there'd be even less to manage (or ignore) in a janus checkout.
