### PR TITLE
Check for Rake::DSL to prevent uninitialized constant error.

### DIFF
--- a/janus/ruby/janus/plugins.rb
+++ b/janus/ruby/janus/plugins.rb
@@ -2,7 +2,7 @@ require 'rake'
 require 'open-uri'
 
 module Janus
-  include Rake::DSL
+  include Rake::DSL if defined?(Rake::DSL)
 
   def self.included(base)
     # Load all plugin installation tasks


### PR DESCRIPTION
Running with older rakes can cause:
    rake aborted!
    uninitialized constant Rake::DSL
