### PR TITLE
Namespace backup/swap files by filename

### DIFF
--- a/janus/vim/core/before/plugin/settings.vim
+++ b/janus/vim/core/before/plugin/settings.vim
@@ -64,5 +64,5 @@ set wildignore+=*.swp,*~,._*
 "" Backup and swap files
 ""
 
-set backupdir=~/.vim/_backup    " where to put backup files.
-set directory=~/.vim/_temp      " where to put swap files.
+set backupdir=~/.vim/_backup//    " where to put backup files.
+set directory=~/.vim/_temp//      " where to put swap files.


### PR DESCRIPTION
Currently, backup/swap of files with the same name will overwrite each other.
This triggers a built-in namespacing feature for this use case.

From vim help:

> For Unix and Win32, if a directory ends in two path separators,
> the swap file name will be built from the complete path to the file
> with all path separators substituted to percent '%' signs.
> This will ensure file name uniqueness in the preserve directory.
