### PR TITLE
Add comment toggle mapping for non-MacVim (using Alt-/).

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -72,6 +72,10 @@ else
   " Ctrl-e for ConqueTerm
   map <C-e> :call StartTerm()<CR>
 
+  " Alt-/ to toggle comments
+  map <A-/> <plug>NERDCommenterToggle<CR>
+  imap <A-/> <Esc><plug>NERDCommenterToggle<CR>i
+
   " Alt-][ to increase/decrease indentation
   vmap <A-]> >gv
   vmap <A-[> <gv


### PR DESCRIPTION
This was one of the mappings for MacVim that wasn't included for non-MacVim usages.  Couldn't use Ctrl-/ because that triggers the buffer search mapping.  Alt-/ works fine.
