### PR TITLE
Perform <C-[Ff]> check even if ack isn't installed

### DIFF
--- a/janus/vim/tools/janus/after/plugin/ack.vim
+++ b/janus/vim/tools/janus/after/plugin/ack.vim
@@ -2,14 +2,17 @@ if has("gui_macvim")
   " Command-Shift-F on OSX
   call janus#add_mapping('ack', 'map', '<D-F>', ':Ack<space>')
 else
-  " Control-Shift-F on other systems
-  call janus#add_mapping('ack', 'map', '<C-F>', ':Ack<space>')
+  " Define <C-F> to a dummy value to see if it would set <C-f> as well.
+  map <C-F> :dummy
 
-  " Check if we defined <C-f> in the process
-  if maparg("<C-f>") == ":Ack "
-    " >leader>f on systems where <C-f> == <C-F>
+  if maparg("<C-f>") == ":dummy"
+    " <leader>f on systems where <C-f> == <C-F>
     call janus#add_mapping('ack', 'map', '<leader>f', ':Ack<space>')
-    map <C-f> <S-Down>
-  end
+  else
+    " <C-F> if we can still map <C-f> to <S-Down>
+    call janus#add_mapping('ack', 'map', '<C-F>', ':Ack<space>')
+  endif
+
+  map <C-f> <S-Down>
 endif
 


### PR DESCRIPTION
Janus sets `<C-F>` to perform an ack search on non-Mac platforms, but only if we can map `<C-F>` and `<C-f>` to different commands.  The way this was checked would only work if ack was present, though.  (If ack isn't present, `<C-f>` is mapped to an error message, and not to `":Ack "`.)  We now set `<C-F>` to a dummy value, perform the `<C-F>` / `<C-f>` check, and then set `<C-F>`, `<C-f>`, and `<leader>f` as appropriate.
