### PR TITLE
Made all has("gui_macvim") checks also check if has("gui_running"). This fixes #355

### DIFF
--- a/janus/vim/core/before/plugin/mappings.vim
+++ b/janus/vim/core/before/plugin/mappings.vim
@@ -67,7 +67,7 @@ nmap <leader>hs :set hlsearch! hlsearch?<CR>
 " Adjust viewports to the same size
 map <Leader>= <C-w>=
 
-if has("gui_macvim")
+if has("gui_macvim") && has("gui_running")
   " Map command-[ and command-] to indenting or outdenting
   " while keeping the original selection in visual mode
   vmap <D-]> >gv

--- a/janus/vim/tools/janus/after/plugin/NERD_commenter.vim
+++ b/janus/vim/tools/janus/after/plugin/NERD_commenter.vim
@@ -1,5 +1,5 @@
 " NERDCommenter mappings
-if has("gui_macvim")
+if has("gui_macvim") && has("gui_running")
   call janus#add_mapping('nerdcommenter', 'map', '<D-/>', '<plug>NERDCommenterToggle<CR>')
   call janus#add_mapping('nerdcommenter', 'imap', '<D-/>', '<Esc><plug>NERDCommenterToggle<CR>i')
 else

--- a/janus/vim/tools/janus/after/plugin/ack.vim
+++ b/janus/vim/tools/janus/after/plugin/ack.vim
@@ -1,4 +1,4 @@
-if has("gui_macvim")
+if has("gui_macvim") && has("gui_running")
   " Command-Shift-F on OSX
   call janus#add_mapping('ack', 'map', '<D-F>', ':Ack<space>')
 else

--- a/janus/vim/tools/janus/after/plugin/ctrlp.vim
+++ b/janus/vim/tools/janus/after/plugin/ctrlp.vim
@@ -2,7 +2,7 @@ if janus#is_plugin_enabled("ctrlp")
   let g:ctrlp_map = ''
 endif
 
-if has("gui_macvim")
+if has("gui_macvim") && has("gui_running")
   call janus#add_mapping('ctrlp', 'map', '<D-t>', ':CtrlP<CR>')
   call janus#add_mapping('ctrlp', 'imap', '<D-t>', '<ESC>:CtrlP<CR>')
 else


### PR DESCRIPTION
Made all has("gui_macvim") checks also check if has("gui_running") this way the cli version of macvim gets mappins without the use of the command key on mac. Fixes #355
