### PR TITLE
Updated submodule Getafe (Vim color theme) Git repository location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/telamon/vim-color-github.git
 [submodule "janus/vim/colors/getafe"]
 	path = janus/vim/colors/getafe
-	url = https://github.com:larssmit/vim-getafe.git
+	url = https://github.com/larssmit/vim-getafe.git
 [submodule "janus/vim/colors/janus-colors"]
 	path = janus/vim/colors/janus-colors
 	url = https://github.com/TechnoGate/janus-colors.git


### PR DESCRIPTION
I cleaned up my Getafe Vim color theme repository (moved iTerm2 en TextMate themes to separate repo's) and changed the location of this repository in Janus. 
