### PR TITLE
CtrlP: Do not manage working directory by default.

### DIFF
--- a/janus/vim/tools/janus/after/plugin/ctrlp.vim
+++ b/janus/vim/tools/janus/after/plugin/ctrlp.vim
@@ -1,5 +1,6 @@
 if janus#is_plugin_enabled("ctrlp")
   let g:ctrlp_map = ''
+  let g:ctrlp_working_path_mode = 0
 endif
 
 if has("gui_macvim") && has("gui_running")


### PR DESCRIPTION
So user doesn't always have to go back to the project's root directory whenever a file in a subdirectory is opened.
