### PR TITLE
small bugfix in NERDTree configuration

### DIFF
--- a/janus/vim/tools/janus/after/plugin/nerdtree.vim
+++ b/janus/vim/tools/janus/after/plugin/nerdtree.vim
@@ -1,5 +1,5 @@
 if janus#is_plugin_enabled("nerdtree")
-  let NERDTreeIgnore=['\.pyc$', '\.pyo$', '\.rbc$', '\.rbo$', '\.class$', '\.o', '\~$']
+  let NERDTreeIgnore=['\.pyc$', '\.pyo$', '\.rbc$', '\.rbo$', '\.class$', '\.o$', '\~$']
   let NERDTreeHijackNetrw = 0
 
   augroup AuNERDTreeCmd


### PR DESCRIPTION
added $ after .o because most people want to see files/folders that contain ".o" but ignore files that END on .o
