### PR TITLE
Adds some backticks to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Tagbar is a vim plugin for browsing the tags of source code files.
 ## [EasyMotion](https://github.com/Lokaltog/vim-easymotion)
 
 EasyMotion provides a much simpler way to use some motions in vim. It
-takes the <number> out of <number>w or <number>f{char} by highlighting
+takes the `<number>` out of `<number>w` or `<number>f{char}` by highlighting
 all possible choices and allowing you to press one key to jump directly
 to the target.
 


### PR DESCRIPTION
While looking at the README on github it looked like some <leader> strings were getting stripped. turns out they were missing the backticks.
