### PR TITLE
Move scary outdated upgrade instructions to bottom of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ and `~/.vimrc.after` Vim RC files.
 
 ## Updating to the latest version
 
-Note: If you haven't upgraded since Jan 10, 2012, see instructions near
-the bottom of this readme.
+(Note: If you haven't upgraded since Jan 10, 2012, see instructions
+[below](https://github.com/galtenberg/janus#alternative-upgrade-steps).)
 
 To update to the latest version of the distribution, just run `rake`
 inside your `~/.vim` directory.


### PR DESCRIPTION
Since it's now late 2012, let's move these instructions lower in the readme.

(See https://github.com/galtenberg/janus)
