### PR TITLE
Limit Ctrl-P cmap to only operate after space

### DIFF
--- a/janus/vim/core/before/plugin/mappings.vim
+++ b/janus/vim/core/before/plugin/mappings.vim
@@ -163,5 +163,5 @@ endif
 "" Command-Line Mappings
 ""
 
-" Insert the current directory into a command-line path
-cmap <C-P> <C-R>=expand("%:p:h") . "/"<CR>
+" After whitespace, insert the current directory into a command-line path
+cnoremap <expr> <C-P> getcmdline()[getcmdpos()-2] ==# ' ' ? expand('%:p:h') : "\<C-P>"


### PR DESCRIPTION
I'd rather see this map go away entirely, but I'm submitting a more
conservative compromise:  Insert the path if a space was the previously
typed character, otherwise fall back to the standard Vim behavior.
