### PR TITLE
Remove superfluous map to :CtrlP

### DIFF
--- a/janus/vim/tools/janus/after/plugin/ctrlp.vim
+++ b/janus/vim/tools/janus/after/plugin/ctrlp.vim
@@ -9,7 +9,4 @@ endif
 if has("gui_macvim") && has("gui_running")
   call janus#add_mapping('ctrlp', 'map', '<D-t>', ':CtrlP<CR>')
   call janus#add_mapping('ctrlp', 'imap', '<D-t>', '<ESC>:CtrlP<CR>')
-else
-  call janus#add_mapping('ctrlp', 'map', '<C-t>', ':CtrlP<CR>')
-  call janus#add_mapping('ctrlp', 'imap', '<C-t>', '<ESC>:CtrlP<CR>')
 endif


### PR DESCRIPTION
I can understand why this might have made sense during a transition from
Command-T.vim, but can it go now?  Both insert mode and normal mode have
a useful default behavior here.
