### PR TITLE
Don't blow up of ~/.vim/_* is missing

### DIFF
--- a/janus/vim/core/before/plugin/settings.vim
+++ b/janus/vim/core/before/plugin/settings.vim
@@ -64,5 +64,5 @@ set wildignore+=*.swp,*~,._*
 "" Backup and swap files
 ""
 
-set backupdir=~/.vim/_backup//    " where to put backup files.
-set directory=~/.vim/_temp//      " where to put swap files.
+set backupdir^=~/.vim/_backup//    " where to put backup files.
+set directory^=~/.vim/_temp//      " where to put swap files.


### PR DESCRIPTION
Presumably this only came to light because of a botched setup process,
but Vim absolutely loses its shit if you set `'directory'` or
`'backupdir'` to contain only directories that don't exist.  Much safer
to prepend.
