### PR TITLE
Markdown wrap settings are hard to override

### DIFF
--- a/janus/vim/core/before/plugin/filetypes.vim
+++ b/janus/vim/core/before/plugin/filetypes.vim
@@ -29,7 +29,8 @@ if has("autocmd")
   endif
 
   " Make sure all mardown files have the correct filetype set and setup wrapping
-  au BufRead,BufNewFile *.{md,markdown,mdown,mkd,mkdn,txt} setf markdown | call s:setupWrapping()
+  au BufRead,BufNewFile *.{md,markdown,mdown,mkd,mkdn,txt} setf markdown
+  au FileType markdown call s:setupWrapping()
 
   " Treat JSON files like JavaScript
   au BufNewFile,BufRead *.json set ft=javascript


### PR DESCRIPTION
I could't find a clean way to override the default setting `textwidth=72` for Markdown files, which is defined in `filetypes.vim`. I tried adding the following to `.vimrc.after`:

```
au FileType markdown set textwidth=0
```

But that setting gets overwritten on `BufEnter` by a function in `filetype.vim`. It's not possible to redefine that function in `.vimrc.after` because it's local to `filetype.vim`.

`filetype.vim` should write the wrap settings on `FileType markdown` rather than on `BufEnter` so that `.vimrc.after` can override those settings by declaring additional autocmds on `FileType markdown`.
