### PR TITLE
Slim submodule causes bad installation.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -190,4 +190,4 @@
 	url = https://github.com/tpope/vim-repeat.git
 [submodule "janus/vim/langs/slim"]
 	path = janus/vim/langs/slim
-	url = git://github.com/slim-template/vim-slim.git
+	url = https://github.com/slim-template/vim-slim.git


### PR DESCRIPTION
I'm behind a proxy. Submodule cannot be downloaded and silently the installation fails. 
It looks like everything is ok but folders for tools submodules are completely empty (not even .git folder)

Any submodule with problems in download could cause this problem as well. I'd would recommend to always set HTTPs protocol in submodule url.
