### PR TITLE
Guardfile is not syntax-highlighted as a Ruby script

### DIFF
--- a/janus/vim/core/before/plugin/filetypes.vim
+++ b/janus/vim/core/before/plugin/filetypes.vim
@@ -25,7 +25,7 @@ if has("autocmd")
   " some reason
   if janus#is_plugin_disabled("ruby")
     " Set the Ruby filetype for a number of common Ruby files without .rb
-    au BufRead,BufNewFile {Gemfile,Rakefile,Vagrantfile,Thorfile,Procfile,config.ru,*.rake} set ft=ruby
+    au BufRead,BufNewFile {Gemfile,Rakefile,Vagrantfile,Thorfile,Procfile,Guardfile,config.ru,*.rake} set ft=ruby
   endif
 
   " Make sure all mardown files have the correct filetype set and setup wrapping


### PR DESCRIPTION
When a `Guardfile` is opened for editing, it is not highlighted as a Ruby script, even though it is one.
