### PR TITLE
Improvement on the <leader>fef mapping

### DIFF
--- a/janus/vim/core/before/plugin/mappings.vim
+++ b/janus/vim/core/before/plugin/mappings.vim
@@ -7,7 +7,7 @@ nmap <silent> <F4> :set invpaste<CR>:set paste?<CR>
 imap <silent> <F4> <ESC>:set invpaste<CR>:set paste?<CR>
 
 " format the entire file
-nmap <leader>fef ggVG=
+nmap <leader>fef ggVG=2<C-o>
 
 " upper/lower word
 nmap <leader>u mQviwU`Q


### PR DESCRIPTION
I've slightly modified the mapping for the `<leader>fef` to go back to the original position of the cursor when the command was executed. 
