### PR TITLE
Improve format entire file mapping.

### DIFF
--- a/janus/vim/core/before/plugin/mappings.vim
+++ b/janus/vim/core/before/plugin/mappings.vim
@@ -7,7 +7,7 @@ nmap <silent> <F4> :set invpaste<CR>:set paste?<CR>
 imap <silent> <F4> <ESC>:set invpaste<CR>:set paste?<CR>
 
 " format the entire file
-nmap <leader>fef ggVG=``
+nnoremap <leader>fef :normal! gg=G``<CR>
 
 " upper/lower word
 nmap <leader>u mQviwU`Q


### PR DESCRIPTION
This is better because:
1) applies the format faster!
2) it isn't jumpy and doesn't select-deselect the text
3) using `normal!` we obtain the same result even if the user remap some
   of those keys
4) avoid remapping (`nnoremap`)
5) `gg=G` is shorter than `ggVG=`
