### PR TITLE
Update settings.vim

### DIFF
--- a/janus/vim/core/before/plugin/settings.vim
+++ b/janus/vim/core/before/plugin/settings.vim
@@ -57,6 +57,9 @@ set wildignore+=*.zip,*.tar.gz,*.tar.bz2,*.rar,*.tar.xz
 " Ignore bundler and sass cache
 set wildignore+=*/vendor/gems/*,*/vendor/cache/*,*/.bundle/*,*/.sass-cache/*
 
+" Ignore rails temporary asset caches
+set wildignore+=*/tmp/cache/assets/*/sprockets/*,*/tmp/cache/assets/*/sass/*
+
 " Disable temp and backup files
 set wildignore+=*.swp,*~,._*
 


### PR DESCRIPTION
Ignore temporary asset caches in Rails. The caches are automatically generated, not meant for manual editing and impair ctrlp's performance.
