### PR TITLE
replaced scala submodule with derekwyatt/vim-scala

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,7 +50,7 @@
 	url = https://github.com/ajf/puppet-vim.git
 [submodule "janus/vim/langs/scala"]
 	path = janus/vim/langs/scala
-  url = https://github.com/rosstimson/scala-vim-support.git
+  url = https://github.com/derekwyatt/vim-scala.git
 [submodule "janus/vim/langs/handlebars"]
 	path = janus/vim/langs/handlebars
 	url = https://github.com/nono/vim-handlebars.git


### PR DESCRIPTION
Hello

I suggest to replace Scala submodule to "derekwyatt/vim-scala" because it seems to be more up to date and has more features (at least detect *.sbt files).
https://github.com/derekwyatt/vim-scala

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/carlhuda/janus/545)
<!-- Reviewable:end -->
