### PR TITLE
Added chef cookbook cache & vagrant dirs to the wildignore list

### DIFF
--- a/janus/vim/core/before/plugin/settings.vim
+++ b/janus/vim/core/before/plugin/settings.vim
@@ -57,6 +57,9 @@ set wildignore+=*.zip,*.tar.gz,*.tar.bz2,*.rar,*.tar.xz
 " Ignore bundler and sass cache
 set wildignore+=*/vendor/gems/*,*/vendor/cache/*,*/.bundle/*,*/.sass-cache/*
 
+" Ignore librarian-chef, vagrant, test-kitchen and Berkshelf cache
+set wildignore+=*/tmp/librarian/*,*/.vagrant/*,*/.kitchen/*,*/vendor/cookbooks/*
+
 " Ignore rails temporary asset caches
 set wildignore+=*/tmp/cache/assets/*/sprockets/*,*/tmp/cache/assets/*/sass/*
 


### PR DESCRIPTION
makes it so CtrlP doesn't pick up the wrong files when working on Chef cookbooks
