### PR TITLE
Change ctrlp_custom_ignore to not ignore Directory.git

### DIFF
--- a/janus/vim/tools/janus/after/plugin/ctrlp.vim
+++ b/janus/vim/tools/janus/after/plugin/ctrlp.vim
@@ -1,7 +1,7 @@
 if janus#is_plugin_enabled("ctrlp")
   let g:ctrlp_map = ''
   let g:ctrlp_custom_ignore = {
-    \ 'dir':  '\.git$\|\.hg$\|\.svn$',
+    \ 'dir':  '\v[\/]\.(git|hg|svn)$',
     \ 'file': '\.pyc$\|\.pyo$\|\.rbc$|\.rbo$\|\.class$\|\.o$\|\~$\',
     \ }
 endif


### PR DESCRIPTION
Consider a directory like `foo.git`.  Given that
this is a default name for a repo as shared by
Github, this is a fairly commmon case.

Within directories such as these, CtlrP will
return **NO ENTRIES**.  If you change the name
from `foo.git` to `foo_git` or just `foo`, you're
fine.

The Regex recommended by @kien in the CtrlP
documentation is:

```
\ 'dir':  '\v[\/]\.(git|hg|svn)$',
```

Using _this_ pattern, CtlrP behaves as expected.
