### PR TITLE
Remove unnecessary -h test

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,7 @@ function die()
 
 # Add <strong>.old</strong> to any existing Vim file in the home directory
 for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do
-  if [[ ( -e $i ) || ( -h $i ) ]]; then
+  if [ -e $i ]; then
     echo "${i} has been renamed to ${i}.old"
     mv "${i}" "${i}.old" || die "Could not move ${i} to ${i}.old"
   fi


### PR DESCRIPTION
You shouldn't need the additional -h test as -e will recognize filesystem objects of any type, including symlinks.

From the bash man pages:

```
-e file
  True if file exists.

-h file
  True if file exists and is a symbolic link.
```

According to the logic from the docs (and a simple empirical test), you don't have to test for both conditions.
