### PR TITLE
Fixed MacVim download link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ brew install macvim
 ```
 
 If you don't use Homebrew, you can still download MacVim
-[here](https://github.com/b4winckler/macvim/downloads).
+[here](https://github.com/b4winckler/macvim/releases).
 
 Take a look at the [Pre-requisites wiki
 page](https://github.com/carlhuda/janus/wiki/Pre-requisites) for more


### PR DESCRIPTION
Since Github's Downloads are deprecated, MacVim packages from previous link were outdated.
