### PR TITLE
Pep 8 standard says "Spaces are the preferred indentation method."

### DIFF
--- a/janus/vim/core/before/plugin/filetypes.vim
+++ b/janus/vim/core/before/plugin/filetypes.vim
@@ -26,7 +26,7 @@ if has("autocmd")
   au BufNewFile,BufRead *.json set ft=javascript
 
   " make Python follow PEP8 for whitespace ( http://www.python.org/dev/peps/pep-0008/ )
-  au FileType python setlocal softtabstop=4 tabstop=4 shiftwidth=4
+  au FileType python setlocal tabstop=4 shiftwidth=4
 
   " Remember last location in file, but not for commit messages.
   " see :help last-position-jump


### PR DESCRIPTION
My problem was:
Create a new file with a .py extension and it uses a tab character instead of spaces.
