### PR TITLE
Update submodule format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 	url = https://github.com/TechnoGate/janus-colors.git
 [submodule "janus/vim/colors/vim-tomorrow-theme"]
 	path = janus/vim/colors/vim-tomorrow-theme
-	url = https://github.com/chriskempson/vim-tomorrow-theme/
+	url = https://github.com/chriskempson/vim-tomorrow-theme.git
 [submodule "janus/vim/colors/base16-vim"]
 	path = janus/vim/colors/base16-vim
 	url = https://github.com/chriskempson/base16-vim


### PR DESCRIPTION
Updating git submodules during `rake update` was throwing

```
Clone of 'https://github.com/chriskempson/vim-tomorrow-theme/' into submodule path 'janus/vim/colors/vim-tomorrow-theme' failed
```

Not sure if it's cause by a new version of git or something, but all other submodules are defined in this format and everything runs successfully this way.