### PR TITLE
Add Support for Windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,9 @@ task :link_vim_conf_files do
       source = expand("../janus/vim/#{file}", __FILE__)
       if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
         require 'open3'
-        dest = dest.gsub(?/, ?\\)
-        source = source.gsub(?/, ?\\)
+        dest.gsub!(?/, ?\\)
+        source.gsub!(?/, ?\\)
+        puts "cmd.exe /c mklink #{dest} #{source}"
         stdin, stdout, stderr, wait_thr = Open3.popen3('cmd.exe', "/c mklink #{dest} #{source}")
         wait_thr.value.exitstatus
       else

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,8 @@ task :link_vim_conf_files do
       source = expand("../janus/vim/#{file}", __FILE__)
       if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
         require 'open3'
+        dest = dest.gsub(?/, ?\\)
+        source = source.gsub(?/, ?\\)
         stdin, stdout, stderr, wait_thr = Open3.popen3('cmd.exe', "/c mklink #{dest} #{source}")
         wait_thr.value.exitstatus
       else

--- a/janus/vim/vimrc
+++ b/janus/vim/vimrc
@@ -3,8 +3,13 @@
 ""
 
 " Define paths
-let g:janus_path = escape(fnamemodify(resolve(expand("<sfile>:p")), ":h"), ' ')
-let g:janus_vim_path = escape(fnamemodify(resolve(expand("<sfile>:p" . "vim")), ":h"), ' ')
+if has('win32') || has('win64') || has('win32unix')
+  let g:janus_path = expand("~/.vim/janus/vim")
+  let g:janus_vim_path = expand("~/.vim/janus/vim")
+else
+  let g:janus_path = escape(fnamemodify(resolve(expand("<sfile>:p")), ":h"), ' ')
+  let g:janus_vim_path = escape(fnamemodify(resolve(expand("<sfile>:p" . "vim")), ":h"), ' ')
+endif
 let g:janus_custom_path = expand("~/.janus")
 
 " Source janus's core


### PR DESCRIPTION
Support installation and use on Windows (using any prompt with `sh` and `bash` support: cygwin, gitbash, etc).

 - Enhanced `git` commands to support Windows syntax for stdout and stderr redirection.
 - Enhanced 'link_vim_conf_files` rake task to use `mklink` to create symlinks when on Windows.
 - Enhanced `.vimrc` to use hard-coded paths to `~/.vim/janus/vim` when loading janus plugins on Windows. (vim does not resolve symlinks to their source on Windows. See [vim issue 147](https://code.google.com/p/vim/issues/detail?id=147))

The standard installation command of `curl -Lo- https://bit.ly/janus-bootstrap | bash` works, but with one requirement: It must be done at an elevated prompt (Run as Administrator). This is because `mklink` can only be executed from an elevated prompt.

See #345

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/carlhuda/janus/613)
<!-- Reviewable:end -->
