### PR TITLE
Replacing broken cheat sheet link with http://vim.rtorr.com/

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Here're some tips in case you've never used VIM before:
   by default. You can, for example, use `let mapleader = ","` to change this to a comma. If you want this
   to be in effect for uses of `<Leader>` in the .vimrc file, make sure to define
   this in `~/.vimrc.before`
-* Keyboard [cheat sheet](http://walking-without-crutches.heroku.com/image/images/vi-vim-cheat-sheet.png).
+* Keyboard [cheat sheet](http://vim.rtorr.com/).
 
 # Features
 


### PR DESCRIPTION
I was hoping to add my vim cheat sheet that has been widely used, currently first result from google for "vim cheat sheet". It seems like the link you had anyway was broken.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/carlhuda/janus/624)
<!-- Reviewable:end -->
