### PR TITLE
Remove redundant curl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ installer](https://github.com/carlhuda/janus/blob/master/bootstrap.sh)
 Janus.
 
 ```bash
-$ curl -Lo- https://bit.ly/janus-bootstrap | bash
+$ curl -L https://bit.ly/janus-bootstrap | bash
 ```
 
 ## Customization

--- a/janus/vim/core/janus/doc/janus.txt
+++ b/janus/vim/core/janus/doc/janus.txt
@@ -80,7 +80,7 @@ installer](https://github.com/carlhuda/janus/blob/master/bootstrap.sh)
 Janus.
 
 ```bash
-$ curl -Lo- http://bit.ly/janus-bootstrap | bash
+$ curl -L http://bit.ly/janus-bootstrap | bash
 ```
 
 


### PR DESCRIPTION
Resolves:

http://stackoverflow.com/q/32899086/why-use-lo-with-curl-when-piping-to-bash

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/carlhuda/janus/639)
<!-- Reviewable:end -->
