### PR TITLE
Guard against nunmap of unset mapping in NarrowRegion plugin

### DIFF
--- a/janus/vim/tools/janus/after/plugin/narrowregion.vim
+++ b/janus/vim/tools/janus/after/plugin/narrowregion.vim
@@ -1,6 +1,6 @@
 if janus#is_plugin_enabled("narrowregion")
   " Change default key mapping in order to eliminate delay related with
   " NERDTree using the same starting sequence <leader>n
-  nunmap <leader>nr
+  silent! nunmap <leader>nr
   call janus#add_mapping('narrowregion', 'map', '<leader>rn', ':NarrowRegion<CR>')
 endif


### PR DESCRIPTION
I noticed during a recent upgrade of janus that the NarrowRegion plugin chirps if you don't already have `<leader>nr` mapped to something. This silences that error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/carlhuda/janus/646)
<!-- Reviewable:end -->
