### PR TITLE
Exclude bower_components and node_modules in CtrlP

### DIFF
--- a/janus/vim/tools/janus/after/plugin/ctrlp.vim
+++ b/janus/vim/tools/janus/after/plugin/ctrlp.vim
@@ -1,7 +1,7 @@
 if janus#is_plugin_enabled("ctrlp")
   let g:ctrlp_map = ''
   let g:ctrlp_custom_ignore = {
-    \ 'dir':  '\v[\/]\.(git|hg|svn)$',
+    \ 'dir':  '\v[\/]\.(git|hg|svn)$|bower_components|node_modules',
     \ 'file': '\.pyc$\|\.pyo$\|\.rbc$|\.rbo$\|\.class$\|\.o$\|\~$\',
     \ }
 endif


### PR DESCRIPTION
Those two directories are very popular among JavaScript developers. They
contain dependencies fetched by external programs which causes slow
downs while searching with CtrlP plugin. There are no sane reasons to
edit those files. Therefore should be excluded.

Closes #611

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/carlhuda/janus/648)
<!-- Reviewable:end -->
