### PR TITLE
Replaced ctrlp submodule with ctrlpvim/ctrlp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -196,7 +196,7 @@
 	url = https://github.com/rgarver/Kwbd.vim.git
 [submodule "janus/vim/tools/ctrlp"]
 	path = janus/vim/tools/ctrlp
-	url = https://github.com/kien/ctrlp.vim.git
+	url = https://github.com/ctrlpvim/ctrlp.vim.git
 [submodule "janus/vim/tools/vroom"]
 	path = janus/vim/tools/vroom
 	url = https://github.com/skalnik/vim-vroom.git


### PR DESCRIPTION
Replaced the unmaintained kien/ctrlp fuzzyfinder repository with the
actively maintained ctrlpvim/ctrlp repository.

https://github.com/ctrlpvim/ctrlp.vim.git

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carlhuda/janus/664)
<!-- Reviewable:end -->
