### PR TITLE
Replace broken link to slides with a new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Here're some tips in case you've never used VIM before:
 
 * Type `vimtutor` into a shell to go through a brief interactive
   tutorial inside VIM.
-* Read the slides at [VIM: Walking Without Crutches](http://walking-without-crutches.heroku.com/#1).
+* Watch this presentation at [VIM: Walking Without Crutches](https://vimeo.com/16458939) or read the [slides on Speaker Deck](https://speakerdeck.com/nelstrom/vim-precision-editing-at-the-speed-of-thought).
 * Watch the screencasts at [vimcasts.org](http://vimcasts.org/)
 * Watch Derek Wyatt's energetic tutorial videos at [his site](http://derekwyatt.org/vim/tutorials/)
 * Read wycats' perspective on learning Vim at


### PR DESCRIPTION
The presentation originally referenced is no longer available as a set of slides, but is still online as a full video or a set of slides, hosted on a new service.