### PR TITLE
fix syntastic defaults, defaulting to passive is unintuitive and shou…

### DIFF
--- a/janus/vim/core/janus/doc/janus.txt
+++ b/janus/vim/core/janus/doc/janus.txt
@@ -317,8 +317,6 @@ execute their script to find them. See `:help syntastic` for details.
 
 **Customizations**: Janus adds a number of customizations to Syntastic:
 
-* Set Syntastic to passive mode by default (use `:SyntasticToggleMode` to
-  toggle modes)
 * Enable the statusline flag
 * Always fill in location lists
 * Open and close error windows automatically

--- a/janus/vim/tools/janus/after/plugin/syntastic.vim
+++ b/janus/vim/tools/janus/after/plugin/syntastic.vim
@@ -5,8 +5,6 @@ if janus#is_plugin_enabled('syntastic')
     set statusline+=%*
   endif
 
-  let g:syntastic_mode_map = {'mode': 'passive'}
-
   let g:syntastic_always_populate_loc_list = 1
   let g:syntastic_auto_loc_list = 1
   let g:syntastic_check_on_open = 1


### PR DESCRIPTION
…ld be done in ones own .vimrc.after, if desired.

The Syntastic default for mode mode was recently changed to "passive" rather than Syntastic's own default of "active," which is the opposite of what anyone using Janus and Syntastic for years would expect. This PR aims to change the default for mode back to "active."