### PR TITLE
Fixes #681, constant errors from Syntastic if Powerline is installed

### DIFF
--- a/janus/vim/tools/janus/after/plugin/syntastic.vim
+++ b/janus/vim/tools/janus/after/plugin/syntastic.vim
@@ -1,5 +1,5 @@
 if janus#is_plugin_enabled('syntastic')
-  if globpath(&runtimepath, 'plugin/airline.vim', 1) ==# '' && globpath(&runtimepath, 'plugin/lightline.vim', 1) ==# ''
+  if globpath(&runtimepath, 'plugin/airline.vim', 1) ==# '' && globpath(&runtimepath, 'plugin/lightline.vim', 1) ==# '' && globpath(&runtimepath, 'plugin/powerline.vim', 1) ==# ''
     set statusline+=%#warningmsg#
     set statusline+=%{SyntasticStatuslineFlag()}
     set statusline+=%*


### PR DESCRIPTION
With powerline installed, opening vim and attempting to do anything will flood the screen with errors like these:

```
E121: Undefined variable: #warningmsg#
E15: Invalid expression: pyeval('powerline.new_window()')%#warningmsg#%{SyntasticStatuslineFlag()}%*
...
```