### PR TITLE
Allow gundo use python3 if available

### DIFF
--- a/janus/vim/core/plugins.vim
+++ b/janus/vim/core/plugins.vim
@@ -3,7 +3,9 @@ let s:no_python_support = "Vim is compiled without python support"
 let s:no_ruby_support = "Vim is compiled without ruby support"
 
 " Plugins that requires python support
-if !has("python")
+if has("python3")
+  let g:gundo_prefer_python3 = 1
+elseif !has("python")
   call janus#disable_plugin("gundo", s:no_python_support)
 endif
 


### PR DESCRIPTION
The plugin gundo.vim has a python dependency, so it's affected by python3 upgrades.

[This gundo.vim issue](https://bitbucket.org/sjl/gundo.vim/issues/42/about-python3-support) mentions the relevant python3 configuration option for gundo.

Sorry if directly creating a PR is against any policies - I didn't find anything regarding 'how to contribute' in the readme, the wiki, or the google groups.